### PR TITLE
Bump Dependencies to latest NodeJS LTS v14.17.6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,8 @@
                "targets": {
                    "node": "6.0.0"
                },
-               "useBuiltIns": "usage"
+               "useBuiltIns": "usage",
+               "corejs": 3
            }
        ]
    ]

--- a/package.json
+++ b/package.json
@@ -33,28 +33,28 @@
   },
   "homepage": "https://github.com/Gyumeijie/github-files-fetcher",
   "dependencies": {
-    "@babel/polyfill": "^7.0.0",
-    "@gyumeijie/cli-progress": "^1.0.0",
-    "args-parser": "^1.1.0",
-    "axios": "^0.18.0",
-    "colors": "^1.3.2",
-    "is-online": "^7.0.0",
-    "shelljs": "^0.8.2"
+    "@gyumeijie/cli-progress": "^1.0.2",
+    "args-parser": "^1.3.0",
+    "axios": "^0.21.4",
+    "colors": "^1.4.0",
+    "is-online": "^9.0.1",
+    "shelljs": "^0.8.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.1.2",
-    "@babel/preset-env": "^7.1.0",
-    "babel-loader": "^8.0.4",
-    "copy-webpack-plugin": "^4.5.3",
-    "cz-conventional-changelog": "^2.1.0",
-    "eslint": "^5.5.0",
-    "eslint-config-airbnb": "^17.1.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.11.1",
-    "webpack": "^4.20.2",
-    "webpack-cli": "^3.1.2",
-    "write-to-file-webpack": "^1.0.4"
+    "@babel/core": "^7.15.5",
+    "@babel/preset-env": "^7.15.6",
+    "babel-loader": "^8.2.2",
+    "copy-webpack-plugin": "^9.0.1",
+    "cz-conventional-changelog": "^3.3.0",
+    "eslint": "^7.32.0",
+    "eslint-config-airbnb": "^18.2.1",
+    "eslint-plugin-react-hooks": "",
+    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-react": "^7.25.2",
+    "webpack": "^5.53.0",
+    "webpack-cli": "^4.8.0",
+    "write-to-file-webpack": "^1.0.6"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "args-parser": "^1.3.0",
     "axios": "^0.21.4",
     "colors": "^1.4.0",
+    "core-js": "^3.17.3",
     "is-online": "^9.0.1",
     "shelljs": "^0.8.4"
   },
@@ -48,10 +49,10 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
-    "eslint-plugin-react-hooks": "",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.25.2",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "webpack": "^5.53.0",
     "webpack-cli": "^4.8.0",
     "write-to-file-webpack": "^1.0.6"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,10 +20,12 @@ module.exports = {
     'electron',
   ],
   plugins: [
-    new CopyWebpackPlugin([
-      { from: 'CHANGELOG.md', to: path.resolve(__dirname, 'dist', 'CHANGELOG.md') },
-      { from: 'README.md', to: path.resolve(__dirname, 'dist', 'README.md') },
-    ]),
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: 'CHANGELOG.md', to: path.resolve(__dirname, 'dist', 'CHANGELOG.md') },
+        { from: 'README.md', to: path.resolve(__dirname, 'dist', 'README.md') },
+      ]
+    }),
     new WriteToFilePlugin({
       filename: path.resolve(__dirname, 'dist/package.json'),
       data() {


### PR DESCRIPTION
Add new, remove deprecated and bump outdated dependencies to latest LTS node (14.17.6).

Removed dependencies:
- @babel/polyfill: As of Babel 7.4.0, this package has been deprecated in favor of directly including core-js/stable (to polyfill ECMAScript features) and regenerator-runtime/runtime

Added dependencies:
- core-js: in replacement of @babel/polyfill above

Updated dependencies: all the others

As stated in this issue #6 , there was some deprecation messages due to outdated dependencies. However, the owner wasn't able to reproduce the error because he uses NodeJS 11.14.0 and this happens only on later versions of NodeJS. 

NodeJS v11 is too old and it makes sense to support the latest LTS release of NodeJS.

